### PR TITLE
add gzip support

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -89,20 +89,20 @@ assertplus.response = function(req, res, callback) {
                 // handle gzipped responses
                 if (response.headers['content-encoding'] == 'gzip') {
                     zlib.gunzip(response.body, function(err, buffer){
-                        if (err) { return callback(err);
+                        if (err) {
+                            return callback(err, response);
                         } else {
                             response.body = buffer.toString(encoding);
                             return callback(err, response);
                         }
                     });
                 } else {
-                    response.body.toString(encoding);
+                    response.body = response.body.toString(encoding);
                     return callback(err, response);
                 }
             }
             catch (e) {
-                err = e;
-                return callback(e);
+                return callback(e, response);
             }
         });
     });

--- a/assert.js
+++ b/assert.js
@@ -75,6 +75,7 @@ assertplus.response = function(req, res, callback) {
 
                 // Assert response body
                 if (res.body !== undefined) {
+                    response.body = response.body.toString(encoding);
                     var eql = res.body instanceof RegExp ?
                         res.body.test(response.body) :
                         res.body === response.body;


### PR DESCRIPTION
To test gzipped responses in api-maps assert-http needs to know how to handle compression before comparing fixture/response

Related to https://github.com/mapbox/api-maps/issues/873

:eyes: @yhahn ?