### PR TITLE
Handle error cases

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -25,6 +25,8 @@ assertplus.response = function(req, res, callback) {
     // Response normalization.
     res.statusCode = res.statusCode || res.status;
 
+    request.on('error', callback);
+
     request.on('response', function(response) {
         var buffers = [];
         response.body = '';

--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ module.exports.runtest = function(test, opts, callback) {
         res.clean = clean;
 
         assert.response(req, res, function(err, response) {
+            if (err) return callback(err);
             var extname = '';
             if (/text\/plain/.test(response.headers['content-type'])) {
                 extname = '.txt';
@@ -340,4 +341,3 @@ function imageEquals(buffer, fixture, options, callback) {
         callback();
     }
 }
-


### PR DESCRIPTION
When using assert-http with node 4+, I'm often hitting this error case:

```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: socket hang up
    at createHangUpError (_http_client.js:200:15)
    at Socket.socketOnEnd (_http_client.js:292:23)
    at emitNone (events.js:72:20)
    at Socket.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at nextTickCallbackWith2Args (node.js:442:9)
    at process._tickDomainCallback (node.js:397:17)
```

This PR adds error handling for requests which `error`. 

/cc @jfirebaugh @yhahn 
