### PR TITLE
Update mapnik to 4.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - "0.10"
   - "4.2.4"
+  - "6.10.3"
 
 before_install:
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - nodejs_version: 6.10.3
+    - nodejs_version: 6.5.0
 
 platform:
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    - nodejs_version: 0.10.40
+    - nodejs_version: 6.10.3
 
 platform:
   - x64

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "sort-keys": "^1.1.2", 
     "underscore": "1.4.x", 
     "assert-diff": "0.0.4", 
-    "mapnik": "3.x"
+    "mapnik": "^4.0.1"
   }, 
   "scripts": {
     "test": "./node_modules/.bin/mocha -R spec"


### PR DESCRIPTION
Update mapnik to 4.0.1 for use in https://github.com/mapbox/api-geocoder/pull/2196